### PR TITLE
Add normal sampling technique from real-life patches 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ audio/
 .tox
 .cache
 .coverage
+src/statistical_analysis.py

--- a/src/spiegelib/synth/synth_base.py
+++ b/src/spiegelib/synth/synth_base.py
@@ -144,7 +144,7 @@ class SynthBase(ABC):
 
 
     @abstractmethod
-    def randomize_patch(self, technique):
+    def randomize_patch(self, technique, samples=None):
         """
         This method must be overridden and should have the effect
         of randomizing parameters of the synthesizer. Overridden methods should be
@@ -152,22 +152,28 @@ class SynthBase(ABC):
         Args:
             technique: Defines the sampling technique used for data generation
                 of the parameter space.
+            samples:
         """
 
 
 
     #TODO Add random sampling arguments here to the synth
-    def get_random_example(self, technique):
+    def get_random_example(self, technique, samples=None):
         """
         Returns audio from a new random patch
         Args:
-            technique (str, optional): Defines the sampling technique used for data generation
+            technique (str): Defines the sampling technique used for data generation
                 of the parameter space.
+            samples (nparray, optional): an array of dictionaries where dict `i` represents parameter `i` values,
+             min max ranges to build a normal distribution
         :return: An audio buffer
         :rtype: np.array
         """
-
-        self.randomize_patch(technique)
+        if samples is not None:
+            assert technique == 'normal'
+            self.randomize_patch(technique, samples)
+        else:
+            self.randomize_patch(technique)
         self.render_patch()
         return self.get_audio()
 

--- a/src/spiegelib/synth/synth_dawdreamer.py
+++ b/src/spiegelib/synth/synth_dawdreamer.py
@@ -173,12 +173,7 @@ class SynthDawDreamer(SynthBase):
                         mean = samples[key]['mean']
                         std = samples[key]['std']
                         randomValue = np.random.normal(mean, std)
-                        if randomValue < 0:
-                            random_patch.append((key, 0))
-                        elif randomValue > 1:
-                            random_patch.append((key, 1))
-                        else:
-                            random_patch.append((key, randomValue))
+                        random_patch.append((key, np.clip(randomValue, 0, 1)))
             self.set_patch(random_patch)
         else:
             print("Please load plugin first.")

--- a/src/spiegelib/synth/synth_dawdreamer.py
+++ b/src/spiegelib/synth/synth_dawdreamer.py
@@ -148,21 +148,27 @@ class SynthDawDreamer(SynthBase):
                 of the parameter space.
         """
         if self.loaded_plugin:
+            #Dictionary of i : j, where parameter i must have constant value j
+            #Keep tune, transpose, global volume and switches at constant
+            constantParams = {2: 1, 3: 0.5, 13: 0.5, 44: 1, 66: 1, 88: 1, 110: 1, 132: 1, 154: 1}
             random_patch = []
             #First type
             if technique == "uniform":
                 for key, value in self.patch:
-                    #If we can automate this parameter:
-                    if self.parametersDesc[key]["isAutomatable"] and not self.parametersDesc[key]["isDiscrete"]:
+                    if key in constantParams:
+                        random_patch.append((key, constantParams[key]))
+                    elif self.parametersDesc[key]["isAutomatable"] and not self.parametersDesc[key]["isDiscrete"]:
                         random_patch.append((key, np.random.uniform(0, 1)))
-                    elif self.parametersDesc[key]["isDiscrete"]:
-                        print(f"Parameter{self.parametersDesc[key]} is discrete.")
             if technique == "normal":
                 assert samples is not None
                 for key, value in self.patch:
-                    #If no model of this current param -> model to be 1
-                    if not bool(samples[key]):
-                        random_patch.append((key, 1))
+                    if key in constantParams:
+                        random_patch.append((key, constantParams[key]))
+                    #If no model available of this parameter:
+                    elif not bool(samples[key]):
+                        # We want to randomize cutoff and resonance uniformly.
+                        if key == 0 or key == 1:
+                            random_patch.append((key, np.random.uniform(0, 1)))
                     else:
                         mean = samples[key]['mean']
                         std = samples[key]['std']

--- a/src/spiegelib/synth/synth_dawdreamer.py
+++ b/src/spiegelib/synth/synth_dawdreamer.py
@@ -140,7 +140,7 @@ class SynthDawDreamer(SynthBase):
 
 
     #TODO Implement 3 strategies here! Start with basic uniform
-    def randomize_patch(self, technique):
+    def randomize_patch(self, technique, samples = None):
         """
         Randomize the current patch. Overridden parameteres will be unaffected.
         Args:
@@ -157,7 +157,22 @@ class SynthDawDreamer(SynthBase):
                         random_patch.append((key, np.random.uniform(0, 1)))
                     elif self.parametersDesc[key]["isDiscrete"]:
                         print(f"Parameter{self.parametersDesc[key]} is discrete.")
-
+            if technique == "normal":
+                assert samples is not None
+                for key, value in self.patch:
+                    #If no model of this current param -> model to be 1
+                    if not bool(samples[key]):
+                        random_patch.append((key, 1))
+                    else:
+                        mean = samples[key]['mean']
+                        std = samples[key]['std']
+                        randomValue = np.random.normal(mean, std)
+                        if randomValue < 0:
+                            random_patch.append((key, 0))
+                        elif randomValue > 1:
+                            random_patch.append((key, 1))
+                        else:
+                            random_patch.append((key, randomValue))
             self.set_patch(random_patch)
         else:
             print("Please load plugin first.")


### PR DESCRIPTION
- +- 6500 patches taken from dx7 website [dx7-patches (1).zip](https://github.com/hjdeheer/spiegelib/files/9675476/dx7-patches.1.zip)
- Convert .syx to .json and load parameters
- Create `normal` sampling technique in `randomize_patch` that draws random samples from a normal distribution built from std and mean of an individual parameter
- Fixed parameters: tuning and transpose at 0.5; global volume at 1; all OP Switches at 1

Closes #3 
Closes #5 
Closes #8